### PR TITLE
php8.1 fixed

### DIFF
--- a/src/ClassLoader.php
+++ b/src/ClassLoader.php
@@ -33,7 +33,7 @@ class ClassLoader extends Loader
         parent::init($proxyFileDirPath, $configDir, $handler);
     }
 
-    protected function loadDotenv(): void
+    protected static function loadDotenv(): void
     {
     }
 }


### PR DESCRIPTION
PHP Fatal error:  Cannot make static method Hyperf\Di\ClassLoader::loadDotenv() non static in class Hyperf\AopIntegration\ClassLoader in    vendor/hyperf/aop-integration/src/ClassLoader.php on line 36

fix https://github.com/hyperf/aop-integration/issues/4